### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Q17040301/cccbf8b9-4c8b-4968-997f-b1b13c1b6e94/b2cab589-c648-457b-acf0-55c467a7371d/_apis/work/boardbadge/71a2bf4f-c099-4d54-a0c0-168be6212f35)](https://dev.azure.com/Q17040301/cccbf8b9-4c8b-4968-997f-b1b13c1b6e94/_boards/board/t/b2cab589-c648-457b-acf0-55c467a7371d/Microsoft.RequirementCategory)
 # log_retriever
 Search/Retriever the logs from all server.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Q17040301/cccbf8b9-4c8b-4968-997f-b1b13c1b6e94/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.